### PR TITLE
Add instructions for installing dependencies on macOS using MacPort

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,7 +86,7 @@ port install texlive-latex texlive-latex-extra
 ### Installing Pandoc 
 Please install `pandoc` latest version from here `https://github.com/jgm/pandoc/releases/tag/3.1.2` or newer, following the instructions. Please do not use `apt` for installing `pandoc` as the packages are largely outdated (at least for older Ubuntu distributions).
 
-On macOS, you may install `pandoc` using MacPort:
+On macOS, you may install `pandoc` using MacPorts:
 
 ```bash
 port install pandoc

--- a/README.md
+++ b/README.md
@@ -74,10 +74,23 @@ apt install parallel rename librsvg2-bin
 apt install texlive-full
 ```
 
+### General macOS dependencies
+Installation using [MacPorts](https://www.macports.org) (not minimal):
+
+```bash
+port install librsvg
+port install texlive-latex texlive-latex-extra
+```
 ---  
 
 ### Installing Pandoc 
 Please install `pandoc` latest version from here `https://github.com/jgm/pandoc/releases/tag/3.1.2` or newer, following the instructions. Please do not use `apt` for installing `pandoc` as the packages are largely outdated (at least for older Ubuntu distributions).
+
+On macOS, you may install `pandoc` using MacPort:
+
+```bash
+port install pandoc
+```
 
 ## Compiling a lab with the toolchain
 Clone this repository somewhere in your filesystem. Let's consider that the toolchain is installed in `~/build_tool/`. 


### PR DESCRIPTION
This PR adds a couple of lines to document one way to install the dependencies on macOS. I have tested these instructions only on my own machine.

I'm using MacPort rather than Homebrew despite the latter being more popular. I suspect the instructions would be similar but sadly I can't test on my machine as using two different dependency managers on the same system is a recipe for disaster.